### PR TITLE
Bug fix & improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.DS_Store
+.bin
+.git
+.gitignore
+.bundleignore
+.bundle
+.byebug_history
+.rspec
+tmp
+log
+test
+config/deploy
+public/packs
+public/packs-test
+node_modules
+yarn-error.log
+coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@ COPY Gemfile /railscounter2/Gemfile
 COPY Gemfile.lock /railscounter2/Gemfile.lock
 RUN bundle install
 
+#Install node dependecies
+COPY package.json yarn.lock ./
+RUN yarn install --check-files
+
+#Copy the app
+COPY . ./
+
 # Add a script to be executed every time the container starts.
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,12 @@ services:
     restart: always
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: root
+      MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
       MONGO_INITDB_DATABASE: railscounter2_development
     ports:
       - "27017:27017"
-    networks:
-      mongo:
-        aliases:
-          - mongo
     volumes:
-      - "mongodb:/var/lib/mongodb/data"
+      - "mongodb:/data/db"
 
   mongo-express:
     image: mongo-express
@@ -24,10 +20,8 @@ services:
       - 8081:8081
     environment:
       ME_CONFIG_MONGODB_ADMINUSERNAME: root
-      ME_CONFIG_MONGODB_ADMINPASSWORD: root
-      ME_CONFIG_MONGODB_URL: railscounter2-mongodb://root:root@mongo:27017/
-    networks:
-      - mongo
+      ME_CONFIG_MONGODB_ADMINPASSWORD: ${DB_PASSWORD}
+      ME_CONFIG_MONGODB_URL: railscounter2-mongodb://root:root@db:27017/
     depends_on:
       - db
 
@@ -48,17 +42,14 @@ services:
     container_name: railscounter2-web
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
-    volumes:
-      - .:/railscounter2
     ports:
       - "3000:3000"
     depends_on:
       - db
-    networks:
-      - mongo
 
 networks:
-  mongo:
+  default:
+    name: mongo
 
 volumes:
   mongodb:


### PR DESCRIPTION
- La persistence des données ne fonctionnait pas !!! Pour le verifier,
  sur la version précédente, après avoir incremente le compteur si on exécute :
  `docker-compose down && docker-compose up` le compteur est de nouveau à 0.
  Avec cette version ce n'est pas le cas.
- L'image n'était pas portable car elle n'embarquait ni les dépendences
  nodes ni l'application. Votre version est pratique pour le développement;
  toutefois impossible de lancer votre application dans Kubernetes ou 
  d'envoyer simplement votre application à un utilisateur.
  Si on voulait etre parfaitement propre il faudrait un repertoire dedié
  a l'appli rails. Le `COPY . ./` prends tous les fichiers memes ceux
  non necessaires.
- Ajout d'un `.dockerignore` pour ne pas embarquer les fichiers inutiles
  (genre les repertoires `tmp` or `vendor`
- Ce n'est généralement pas une bonne idée de mettre un mot de passe
  dans un gestionnaire de version (cf. 12 factors). 
  Dans le `docker-compose.yaml` il est possible d'utiliser des   variables d'environnement
  e.g. `DB_PASSWORD=root docker-compose up`.